### PR TITLE
FIT-20894 Fix scanner dark preview

### DIFF
--- a/wrappers/flutter/android/src/main/kotlin/com/fitatu/barcodescanner/fitatu_barcode_scanner/FitatuBarcodeScanner.kt
+++ b/wrappers/flutter/android/src/main/kotlin/com/fitatu/barcodescanner/fitatu_barcode_scanner/FitatuBarcodeScanner.kt
@@ -87,7 +87,7 @@ class FitatuBarcodeScanner(
                     // Those values are copied from zxingcpp android example.
                     // This should reduce motion blur and improve barcode reading
                     setCaptureRequestOption(CaptureRequest.SENSOR_SENSITIVITY, 1600)
-                    setCaptureRequestOption(CaptureRequest.CONTROL_AE_EXPOSURE_COMPENSATION, -8)
+//                    setCaptureRequestOption(CaptureRequest.CONTROL_AE_EXPOSURE_COMPENSATION, -8)
                 }
             }
             .setTargetAspectRatio(AspectRatio.RATIO_16_9)


### PR DESCRIPTION
https://fitatu.atlassian.net/browse/FIT-20894

- [x] disable `CONTROL_AE_EXPOSURE_COMPENSATION` option due to dark camera preview and stack effect on motorola phone 