### PR TITLE
FIT-00000 Mobile scanner start fix

### DIFF
--- a/wrappers/flutter/.fvm/flutter_sdk
+++ b/wrappers/flutter/.fvm/flutter_sdk
@@ -1,0 +1,1 @@
+/Users/sebastianbrulinski/fvm/versions/3.35.5

--- a/wrappers/flutter/.fvm/fvm_config.json
+++ b/wrappers/flutter/.fvm/fvm_config.json
@@ -1,0 +1,4 @@
+{
+  "flutterSdkVersion": "3.35.5",
+  "flavors": {}
+}

--- a/wrappers/flutter/CHANGELOG.md
+++ b/wrappers/flutter/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 5.0.5
+Fixed initialization of the `CommonFitatuScannerPreview` widget. Prevented multiple calls to `start`
+
+## 5.0.4
+* Fixed CMakeLists.txt due to problems with 16KB page size
+
+## 5.0.3
+* Migrated to 16KB page size (Android)
+
+## 5.0.2
+* Bumped `minSdkVersion` from `21` to `24` 
+* Set `ndkVersion` to `27.0.12077973`
+* Bumped AGP to `8.13.1`
+* Updated `mobile_scanner` package to `7.1.2`
+* Updated `pigeon` package to `26.0.1`
+
 ## 5.0.1
 * Update zxing-cpp to current master due to 16KB page support
 

--- a/wrappers/flutter/CHANGELOG.md
+++ b/wrappers/flutter/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 5.0.5
-Fixed initialization of the `CommonFitatuScannerPreview` widget. Prevented multiple calls to `start`
+* Fixed initialization of the `CommonFitatuScannerPreview` widget. Prevented multiple calls to `start`
+* Added `fvm` to the project
+* Bumped flutter from `3.35.1` to `3.35.5`
+* Bumbed `mobile_scanner` from `7.1.2` to `7.1.3`
 
 ## 5.0.4
 * Fixed CMakeLists.txt due to problems with 16KB page size

--- a/wrappers/flutter/example/pubspec.lock
+++ b/wrappers/flutter/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.0.4"
+    version: "5.0.5"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -139,10 +139,10 @@ packages:
     dependency: transitive
     description:
       name: mobile_scanner
-      sha256: "5e7e09d904dc01de071b79b3f3789b302b0ed3c9c963109cd3f83ad90de62ecf"
+      sha256: "023a71afb4d7cfb5529d0f2636aa8b43db66257905b9486d702085989769c5f2"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.2"
+    version: "7.1.3"
   path:
     dependency: transitive
     description:
@@ -286,4 +286,4 @@ packages:
     version: "1.1.1"
 sdks:
   dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.35.1"
+  flutter: ">=3.35.5"

--- a/wrappers/flutter/example/pubspec.yaml
+++ b/wrappers/flutter/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 
 environment:
   sdk: ">=3.8.1 <4.0.0"
-  flutter: ">=3.35.1"
+  flutter: ">=3.35.5"
 
 dependencies:
   flutter:

--- a/wrappers/flutter/lib/src/infra/common/common_fitatu_scanner_preview.dart
+++ b/wrappers/flutter/lib/src/infra/common/common_fitatu_scanner_preview.dart
@@ -27,8 +27,9 @@ class _CommonFitatuScannerPreviewState extends State<_CommonFitatuScannerPreview
   ScannerOptions? get options => widget.controller?.scannerOptions;
 
   Future<void> startController(MobileScannerController? controller) async {
-    await controller?.start();
-    await controller?.resetZoomScale();
+    if (controller == null || controller.value.isStarting) return;
+    await controller.start();
+    await controller.resetZoomScale();
   }
 
   @override
@@ -49,7 +50,7 @@ class _CommonFitatuScannerPreviewState extends State<_CommonFitatuScannerPreview
   Widget build(BuildContext context) {
     return _LifecycleAware(
       onPause: controller?.stop,
-      onResume: controller?.start,
+      onResume: () => startController(controller),
       child: LayoutBuilder(
         builder: (context, constraints) {
           final scanWindowSize = constraints.maxHeight * (options?.cropPercent ?? 0);

--- a/wrappers/flutter/melos.yaml
+++ b/wrappers/flutter/melos.yaml
@@ -1,4 +1,5 @@
 name: fitatu_barcode_scanner
+sdkPath: .fvm/flutter_sdk
 
 packages:
   - .
@@ -7,3 +8,6 @@ packages:
 command:
   bootstrap:
     usePubspecOverrides: true
+    environment:
+      sdk: ">=3.8.1 <4.0.0"
+      flutter: ">=3.35.5"

--- a/wrappers/flutter/pubspec.yaml
+++ b/wrappers/flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fitatu_barcode_scanner
 description: Fitatu implementation of zxing scanner and navite camera API's
 publish_to: none
-version: 5.0.4
+version: 5.0.5
 
 environment:
   sdk: ">=3.8.1 <4.0.0"

--- a/wrappers/flutter/pubspec.yaml
+++ b/wrappers/flutter/pubspec.yaml
@@ -5,14 +5,14 @@ version: 5.0.5
 
 environment:
   sdk: ">=3.8.1 <4.0.0"
-  flutter: ">=3.35.1"
+  flutter: ">=3.35.5"
 
 dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.8
   # support iOS
-  mobile_scanner: ^7.1.2
+  mobile_scanner: ^7.1.3
   permission_handler: ^12.0.1
 
 dev_dependencies:


### PR DESCRIPTION
**🔗 JIRA Link:**
https://fitatu.atlassian.net/browse/FIT-00000

**🛠️ Type of change:**
- Fix
- Chore

**🎯 Purpose of this PR:**
Fixed a Crashlytics-reported crash: [link](https://console.firebase.google.com/u/0/project/api-7023620627109901947-330798/crashlytics/app/ios:com.fitatu.tracker/issues/d4fa70dec877304fd4737f0925ccf8fd?time=7d&versions=4.8.4%20(40199);4.8.4%20(40198);4.8.4%20(40196);4.8.4%20(40195);4.8.4%20(40192);4.8.4%20(40369);4.8.4%20(40368);4.8.4%20(40367);4.8.4%20(40366);4.8.4%20(40365);4.8.4%20(40364);4.8.4%20(40360);4.8.4%20(40363);4.8.4%20(40362);4.8.4%20(40361);4.8.4%20(40010)&sessionEventKey=5f79b6e1577c42f3a58839b896dec18b_2139062179943173497)

I wasn’t able to reproduce the crash locally, but `MobileScannerController` throws a `controllerInitializing` exception if start is called while the controller is already starting. I’ve added a guard clause that exits early whenever `controller.isStarting` is true, preventing those repeated start calls.

The code inside `start` method looks like this:
```dart
if (value.isStarting) {
      throw MobileScannerException(
        errorCode: MobileScannerErrorCode.controllerInitializing,
        errorDetails: MobileScannerErrorDetails(
          message: MobileScannerErrorCode.controllerInitializing.message,
        ),
      );
}
```
