### PR TITLE
FIT-26088 Lock iOS scanner orientation to portrait-up

### DIFF
--- a/wrappers/flutter/CHANGELOG.md
+++ b/wrappers/flutter/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.2.2
+* iOS: lock the `mobile_scanner` orientation to portrait-up to prevent rotated camera previews.
+
 ## 5.2.1
 * Fix the `ResourceLeaseManager` so a release call made before creation still waits for creation and runs the release callback.
 

--- a/wrappers/flutter/example/pubspec.lock
+++ b/wrappers/flutter/example/pubspec.lock
@@ -55,7 +55,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.2.1"
+    version: "5.2.2"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/wrappers/flutter/lib/src/fitatu_barcode_scanner.dart
+++ b/wrappers/flutter/lib/src/fitatu_barcode_scanner.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 
 import 'package:fitatu_barcode_scanner/fitatu_barcode_scanner.dart';
 import 'package:fitatu_barcode_scanner/src/infra/android/camera_permissions_guard.dart';
+import 'package:fitatu_barcode_scanner/src/infra/common/fitatu_mobile_scanner_platform.dart';
 import 'package:fitatu_barcode_scanner/src/pigeons/fitatu_barcode_scanner.pigeon.dart';
 import 'package:fitatu_barcode_scanner/src/scanner_preview_mixin.dart';
 import 'package:flutter/foundation.dart';
@@ -132,9 +133,12 @@ final class _AndroidBarcodeScanner extends FitatuBarcodeScannerController {
 }
 
 final class _IOSBarcodeScanner extends FitatuBarcodeScannerController {
-  _IOSBarcodeScanner(super.options) : _controller = MobileScannerController(autoStart: false);
+  _IOSBarcodeScanner(super.options) {
+    MobileScannerPlatform.instance = FitatuMobileScannerPlatform();
+    _controller = MobileScannerController(autoStart: false);
+  }
 
-  final MobileScannerController _controller;
+  late final MobileScannerController _controller;
 
   @override
   Future<void> disposeController() => _controller.dispose();

--- a/wrappers/flutter/lib/src/infra/common/fitatu_mobile_scanner_platform.dart
+++ b/wrappers/flutter/lib/src/infra/common/fitatu_mobile_scanner_platform.dart
@@ -1,0 +1,16 @@
+// ignore_for_file: implementation_imports
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/src/services/system_chrome.dart';
+import 'package:mobile_scanner/src/method_channel/mobile_scanner_method_channel.dart';
+
+final class FitatuMobileScannerPlatform extends MethodChannelMobileScanner {
+  FitatuMobileScannerPlatform({this.workingOrientation = DeviceOrientation.portraitUp});
+
+  /// Orientation value returned by the platform stream; defaults to portrait.
+  final DeviceOrientation workingOrientation;
+
+  @nonVirtual
+  @override
+  Stream<DeviceOrientation> get deviceOrientationChangedStream => Stream.value(workingOrientation);
+}

--- a/wrappers/flutter/lib/src/utility/resource_lease_manager.dart
+++ b/wrappers/flutter/lib/src/utility/resource_lease_manager.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 import 'dart:developer' as dev;
 import 'dart:collection';
 
-import 'package:flutter/foundation.dart';
-
 /// Asynchronous factory invoked when a lease becomes active.
 ///
 /// - Called when the lease reaches the front of the queue.

--- a/wrappers/flutter/pubspec.yaml
+++ b/wrappers/flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fitatu_barcode_scanner
 description: Fitatu implementation of zxing scanner and navite camera API's
 publish_to: none
-version: 5.2.1
+version: 5.2.2
 
 environment:
   sdk: ">=3.8.1 <4.0.0"


### PR DESCRIPTION
**🔗 JIRA Link:**
https://fitatu.atlassian.net/browse/FIT-FIT-26088

**🛠️ Type of change:**
Fix 

**🎯 Purpose of this PR:**
Force camera orientation to DeviceOrientation.portraitUp by overriding MobileScanner’s internal orientation stream.
Uses non-public API to pin orientation; temporary hack to avoid rotation issues until upstream support exists.
